### PR TITLE
Fix coach integ tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -57,11 +57,14 @@ def toolkit(request):
 
 
 @pytest.fixture(scope='session')
-def toolkit_version(request, toolkit):
+def toolkit_version(request, toolkit, framework):
     provided_version = request.config.getoption('--toolkit-version')
     if not provided_version:
         if toolkit == 'coach':
-            return RLEstimator.COACH_LATEST_VERSION
+            if framework == 'tensorflow':
+                return RLEstimator.COACH_LATEST_VERSION_TF
+            if framework == 'mxnet':
+                return RLEstimator.COACH_LATEST_VERSION_MXNET
         if toolkit == 'ray':
             return RLEstimator.RAY_LATEST_VERSION
     return provided_version

--- a/test/resources/gym/gym_envs.py
+++ b/test/resources/gym/gym_envs.py
@@ -36,7 +36,7 @@ def run_simulation(env_name, output_dir):
         env.reset()
         total_reward = 0
         for step in range(1000):
-            env.render(mode='rgb_array')
+            env.render(mode='ansi')
             action = env.action_space.sample()  # your agent here (this takes random actions)
             observation, reward, done, info = env.step(action)
             total_reward += reward


### PR DESCRIPTION
*Description of changes:*
There were two errors. The first was due to https://github.com/aws/sagemaker-python-sdk/pull/684 - the public constants for coach versions in the Python SDK changed.

The second was this error:
```
Traceback (most recent call last):
File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
"__main__", mod_spec)
File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
exec(code, run_globals)
File "/opt/ml/code/gym_envs.py", line 76, in <module>
run_simulation(env_name, '/opt/ml/output/intermediate')
File "/opt/ml/code/gym_envs.py", line 39, in run_simulation
env.render(mode='rgb_array')
File "/usr/local/lib/python3.5/dist-packages/gym/core.py", line 249, in render
return self.env.render(mode, **kwargs)
File "/usr/local/lib/python3.5/dist-packages/gym/core.py", line 249, in render
return self.env.render(mode, **kwargs)
File "/usr/local/lib/python3.5/dist-packages/gym/envs/algorithmic/algorithmic_env.py", line 156, in render
return outfile.getvalue()
AttributeError: '_io.TextIOWrapper' object has no attribute 'getvalue'
```
I'm not entirely sure what caused this, as [this line of code in openai gym](https://github.com/openai/gym/blob/master/gym/envs/algorithmic/algorithmic_env.py#L117) is three years old, `sys.stdout` hasn't been a StringIO object for at least two and a half years (based on [what I found on StackOverflow](https://stackoverflow.com/q/40045963)), and our test code hasn't changed during the time that this error started cropping up.

The following test commands passed for me:
```bash
$ pytest test/integration/sagemaker/ --framework tensorflow --toolkit ray --aws-id 520713654638 -n auto
$ pytest test/integration/sagemaker/ --framework tensorflow --toolkit coach --aws-id 520713654638 -n auto
$ pytest test/integration/sagemaker/ --framework mxnet --toolkit coach --aws-id 520713654638 -n auto
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
