### PR TITLE
fix: pin gym version to 0.12.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 
-    install_requires=['numpy', 'tox', 'flake8', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
-                      'sagemaker', 'docker-compose'],
+    install_requires=['numpy', 'tox', 'flake8', 'pytest==4.4.2', 'pytest-cov', 'pytest-xdist',
+                      'mock', 'sagemaker', 'docker-compose'],
 )

--- a/test/resources/gym/requirements.txt
+++ b/test/resources/gym/requirements.txt
@@ -1,3 +1,3 @@
-gym[atari]
-gym[box2d]
+gym[atari]==0.12.6
+gym[box2d]==0.12.6
 box2d-py>=2.3.5


### PR DESCRIPTION
gym 0.13.0 was released 6/21 and requires an atari_py version that doesn't support python 3.5. pinning version of gym in test code to last version that supports 3.5.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
