### PR TITLE
Correct pyglet library version to prevent gym environment notebooks from failing.

### DIFF
--- a/ray/docker/0.8.2/Dockerfile.tf
+++ b/ray/docker/0.8.2/Dockerfile.tf
@@ -39,6 +39,9 @@ RUN pip install --no-cache-dir \
     setproctitle \
     tensorflow-probability
 
+# https://github.com/aws/sagemaker-rl-container/issues/39
+RUN pip install pyglet==1.3.2
+
 # https://click.palletsprojects.com/en/7.x/python3/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/ray/docker/0.8.5/Dockerfile.tf
+++ b/ray/docker/0.8.5/Dockerfile.tf
@@ -40,6 +40,9 @@ RUN pip install --no-cache-dir \
     dm-tree \
     tensorflow-probability
 
+# https://github.com/aws/sagemaker-rl-container/issues/39
+RUN pip install pyglet==1.3.2
+
 # https://click.palletsprojects.com/en/7.x/python3/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/ray/docker/0.8.5/Dockerfile.torch
+++ b/ray/docker/0.8.5/Dockerfile.torch
@@ -39,6 +39,9 @@ RUN pip install --no-cache-dir \
     dm-tree \
     tensorflow-probability
 
+# https://github.com/aws/sagemaker-rl-container/issues/39
+RUN pip install pyglet==1.3.2
+
 # https://click.palletsprojects.com/en/7.x/python3/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
*Issue #39 

Install pyglet 1.3.2 in Docker files for RLlib.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
