### PR TITLE
Update  RLEstimator params in tests.

### DIFF
--- a/test/integration/local/test_coach.py
+++ b/test/integration/local/test_coach.py
@@ -32,10 +32,10 @@ def test_cartpole(docker_image, sagemaker_local_session, processor, tmpdir):
     estimator = RLEstimator(entry_point=cartpole,
                             source_dir=source_dir,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=instance_type,
+                            instance_count=1,
+                            instance_type=instance_type,
                             sagemaker_session=sagemaker_local_session,
-                            image_name=docker_image,
+                            image_uri=docker_image,
                             output_path='file://{}'.format(tmpdir),
                             dependencies=dependencies,
                             hyperparameters={

--- a/test/integration/local/test_gym.py
+++ b/test/integration/local/test_gym.py
@@ -27,11 +27,11 @@ def test_gym(local_instance_type, sagemaker_local_session, docker_image, tmpdir,
     estimator = RLEstimator(entry_point=gym_script,
                             source_dir=source_path,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=local_instance_type,
+                            instance_count=1,
+                            instance_type=local_instance_type,
                             sagemaker_session=sagemaker_local_session,
                             output_path='file://{}'.format(tmpdir),
-                            image_name=docker_image)
+                            image_uri=docker_image)
     estimator.fit()
 
     local_mode_utils.assert_output_files_exist(str(tmpdir), 'output', ['success'])

--- a/test/integration/local/test_ray.py
+++ b/test/integration/local/test_ray.py
@@ -29,11 +29,11 @@ def test_ray(local_instance_type, sagemaker_local_session, docker_image, tmpdir,
     estimator = RLEstimator(entry_point=cartpole,
                             source_dir=source_dir,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=local_instance_type,
+                            instance_count=1,
+                            instance_type=local_instance_type,
                             sagemaker_session=sagemaker_local_session,
                             output_path='file://{}'.format(tmpdir),
-                            image_name=docker_image)
+                            image_uri=docker_image)
 
     estimator.fit()
 

--- a/test/integration/local/test_vw_cb_explore.py
+++ b/test/integration/local/test_vw_cb_explore.py
@@ -27,12 +27,12 @@ def test_vw_cb_explore(local_instance_type, sagemaker_local_session, docker_imag
     estimator = RLEstimator(entry_point="train_cb_explore.py",
                             source_dir=source_path,
                             role=role,
-                            train_instance_count=1,
+                            instance_count=1,
+                            instance_type=local_instance_type,
                             hyperparameters={"num_arms": 7},
-                            train_instance_type=local_instance_type,
                             sagemaker_session=sagemaker_local_session,
                             output_path='file://{}'.format(tmpdir),
-                            image_name=docker_image)
+                            image_uri=docker_image)
     estimator.fit(inputs=training_data_bandits)
 
     local_mode_utils.assert_output_files_exist(str(tmpdir), 'output', ['success'])
@@ -46,12 +46,12 @@ def test_vw_cb_explore_pretrained_model(local_instance_type, sagemaker_local_ses
     estimator = RLEstimator(entry_point="train_cb_explore.py",
                             source_dir=source_path,
                             role=role,
-                            train_instance_count=1,
+                            instance_count=1,
+                            instance_type=local_instance_type,
                             hyperparameters={"num_arms": 7},
-                            train_instance_type=local_instance_type,
                             sagemaker_session=sagemaker_local_session,
                             output_path='file://{}'.format(tmpdir),
-                            image_name=docker_image,
+                            image_uri=docker_image,
                             model_channel_name="pretrained_model",
                             model_uri=pretrained_model_vw)
     

--- a/test/integration/local/test_vw_cbify.py
+++ b/test/integration/local/test_vw_cbify.py
@@ -27,12 +27,12 @@ def test_vw_cb_explore(local_instance_type, sagemaker_local_session, docker_imag
     estimator = RLEstimator(entry_point="train_cbify.py",
                             source_dir=source_path,
                             role=role,
-                            train_instance_count=1,
+                            instance_count=1,
+                            instance_type=local_instance_type,
                             hyperparameters={"num_arms": 7},
-                            train_instance_type=local_instance_type,
                             sagemaker_session=sagemaker_local_session,
                             output_path='file://{}'.format(tmpdir),
-                            image_name=docker_image)
+                            image_uri=docker_image)
     estimator.fit(inputs=training_data_supervised)
 
     local_mode_utils.assert_output_files_exist(str(tmpdir), 'output', ['success'])

--- a/test/integration/sagemaker/test_coach.py
+++ b/test/integration/sagemaker/test_coach.py
@@ -29,10 +29,10 @@ def test_coach(sagemaker_session, ecr_image, instance_type):
     estimator = RLEstimator(entry_point=cartpole,
                             source_dir=source_dir,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=instance_type,
+                            instance_count=1,
+                            instance_type=instance_type,
                             sagemaker_session=sagemaker_session,
-                            image_name=ecr_image,
+                            image_uri=ecr_image,
                             dependencies=dependencies,
                             hyperparameters={
                                 "save_model": 1,

--- a/test/integration/sagemaker/test_gym.py
+++ b/test/integration/sagemaker/test_gym.py
@@ -25,10 +25,10 @@ def test_gym(sagemaker_session, ecr_image, instance_type, framework):
     estimator = RLEstimator(entry_point=gym_script,
                             source_dir=resource_path,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=instance_type,
+                            instance_count=1,
+                            instance_type=instance_type,
                             sagemaker_session=sagemaker_session,
-                            image_name=ecr_image)
+                            image_uri=ecr_image)
 
     with timeout(minutes=15):
         estimator.fit()

--- a/test/integration/sagemaker/test_ray.py
+++ b/test/integration/sagemaker/test_ray.py
@@ -28,10 +28,10 @@ def test_ray(sagemaker_session, ecr_image, instance_type, framework):
     estimator = RLEstimator(entry_point=cartpole,
                             source_dir=source_dir,
                             role='SageMakerRole',
-                            train_instance_count=1,
-                            train_instance_type=instance_type,
+                            instance_count=1,
+                            instance_type=instance_type,
                             sagemaker_session=sagemaker_session,
-                            image_name=ecr_image)
+                            image_uri=ecr_image)
 
     with timeout(minutes=15):
         estimator.fit()


### PR DESCRIPTION
* Recent breaking changes introduced a bug where 'image_name' param is no longer applicable: https://github.com/aws/sagemaker-python-sdk/pull/1667


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
