### PR TITLE
Add `tf_slim` package to Ray docker images for versions 0.8.2 and 0.8.5.

### DIFF
--- a/ray/docker/0.8.2/Dockerfile.tf
+++ b/ray/docker/0.8.2/Dockerfile.tf
@@ -37,7 +37,8 @@ RUN pip install --no-cache-dir \
     scipy \
     psutil \
     setproctitle \
-    tensorflow-probability
+    tensorflow-probability \
+    tf_slim
 
 # https://github.com/aws/sagemaker-rl-container/issues/39
 RUN pip install pyglet==1.3.2

--- a/ray/docker/0.8.5/Dockerfile.tf
+++ b/ray/docker/0.8.5/Dockerfile.tf
@@ -38,7 +38,8 @@ RUN pip install --no-cache-dir \
     psutil \
     setproctitle \
     dm-tree \
-    tensorflow-probability
+    tensorflow-probability \
+    tf_slim
 
 # https://github.com/aws/sagemaker-rl-container/issues/39
 RUN pip install pyglet==1.3.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* TF2.x doesn't contain `tensorflow.contrib.slim` package. This is available as part of the `tf_slim` package that is independent of tensorflow. This change will enable the Ray image with TF2.x to also have the `slim` package installed and be available for notebooks that currently rely on `slim`'s functionality.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
