### PR TITLE
Update awscli on latest Ray, Coach and VW images

### DIFF
--- a/coach/docker/1.0.0/Dockerfile.tf
+++ b/coach/docker/1.0.0/Dockerfile.tf
@@ -23,6 +23,10 @@ RUN cd /tmp && \
     make && \
     make install
 
+# Update awscli for compatibility with the latest botocore version that breaks it
+# https://github.com/boto/boto3/issues/2596
+RUN pip install --upgrade awscli
+
 RUN pip install --no-cache-dir \
     PyOpenGL==3.1.0 \
     pyglet==1.3.2 \

--- a/ray/docker/0.8.2/Dockerfile.tf
+++ b/ray/docker/0.8.2/Dockerfile.tf
@@ -18,7 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
+# Update awscli for compatibility with the latest botocore version that breaks it
+# https://github.com/boto/boto3/issues/2596
+RUN pip install --upgrade pip awscli
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/ray/docker/0.8.5/Dockerfile.tf
+++ b/ray/docker/0.8.5/Dockerfile.tf
@@ -18,7 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
+# Update awscli for compatibility with the latest botocore version that breaks it
+# https://github.com/boto/boto3/issues/2596
+RUN pip install --upgrade pip awscli
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/ray/docker/0.8.5/Dockerfile.torch
+++ b/ray/docker/0.8.5/Dockerfile.torch
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
+# Update awscli for compatibility with the latest botocore version that breaks it
+# https://github.com/boto/boto3/issues/2596
+RUN pip install --upgrade pip awscli
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/vw/docker/8.7.0/Dockerfile
+++ b/vw/docker/8.7.0/Dockerfile
@@ -44,6 +44,10 @@ RUN \
   make && \
   make install
 
+# Update awscli for compatibility with the latest botocore version that breaks it
+# https://github.com/boto/boto3/issues/2596
+RUN pip install --upgrade awscli
+
 RUN pip install ipython \
                 sagemaker-containers==2.5.1 \
                 redis==3.2.1 \


### PR DESCRIPTION
* This change fixes the 'docevents' import error  due to an upgrade in botocore. https://github.com/boto/boto3/issues/2596

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
