### PR TITLE
Update awscli on all buildspecs

### DIFF
--- a/buildspec-coach.yml
+++ b/buildspec-coach.yml
@@ -37,6 +37,9 @@ phases:
       # install
       - echo "install"
       - pip3 install -U -e .
+      # Update awscli for compatibility with the latest botocore version that breaks it
+      # https://github.com/boto/boto3/issues/2596
+      - pip3 install --upgrade awscli
 
       # launch remote gpu instance only in region us-west-2
       - |

--- a/buildspec-ray.yml
+++ b/buildspec-ray.yml
@@ -37,6 +37,9 @@ phases:
       # install
       - echo "install"
       - pip3 install -U -e .
+      # Update awscli for compatibility with the latest botocore version that breaks it
+      # https://github.com/boto/boto3/issues/2596
+      - pip3 install --upgrade awscli
 
       # launch remote gpu instance only in region us-west-2
       - |

--- a/buildspec-vw.yml
+++ b/buildspec-vw.yml
@@ -35,6 +35,9 @@ phases:
       # install dependencies
       - echo "installing dependencies"
       - pip3 install -U pytest==4.4.2 pytest-cov pytest-xdist mock tox flake8 sagemaker
+      # Update awscli for compatibility with the latest botocore version that breaks it
+      # https://github.com/boto/boto3/issues/2596
+      - pip3 install --upgrade awscli
 
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids $ACCOUNT)
       - BUILD_ID="$(echo $CODEBUILD_BUILD_ID | sed -e 's/:/-/g' | tr '[:upper:]' '[:lower:]')"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,6 +36,9 @@ phases:
       # install
       - echo "install"
       - pip3 install -U -e .
+      # Update awscli for compatibility with the latest botocore version that breaks it
+      # https://github.com/boto/boto3/issues/2596
+      - pip3 install --upgrade awscli
 
       # launch remote gpu instance
       - echo "launch remote gpu instance"

--- a/coach/docker/1.0.0/Dockerfile.tf
+++ b/coach/docker/1.0.0/Dockerfile.tf
@@ -23,10 +23,6 @@ RUN cd /tmp && \
     make && \
     make install
 
-# Update awscli for compatibility with the latest botocore version that breaks it
-# https://github.com/boto/boto3/issues/2596
-RUN pip install --upgrade awscli
-
 RUN pip install --no-cache-dir \
     PyOpenGL==3.1.0 \
     pyglet==1.3.2 \

--- a/ray/docker/0.8.2/Dockerfile.tf
+++ b/ray/docker/0.8.2/Dockerfile.tf
@@ -18,9 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Update awscli for compatibility with the latest botocore version that breaks it
-# https://github.com/boto/boto3/issues/2596
-RUN pip install --upgrade pip awscli
+RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/ray/docker/0.8.5/Dockerfile.tf
+++ b/ray/docker/0.8.5/Dockerfile.tf
@@ -18,9 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Update awscli for compatibility with the latest botocore version that breaks it
-# https://github.com/boto/boto3/issues/2596
-RUN pip install --upgrade pip awscli
+RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/ray/docker/0.8.5/Dockerfile.torch
+++ b/ray/docker/0.8.5/Dockerfile.torch
@@ -17,9 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Update awscli for compatibility with the latest botocore version that breaks it
-# https://github.com/boto/boto3/issues/2596
-RUN pip install --upgrade pip awscli
+RUN pip install --upgrade pip
 
 RUN pip install --no-cache-dir \
     Cython==0.29.7 \

--- a/src/vw-serving/src/vw_serving/serve.py
+++ b/src/vw-serving/src/vw_serving/serve.py
@@ -11,7 +11,7 @@ import datetime
 import random
 
 import numpy as np
-from gunicorn.six import iteritems
+from six import iteritems
 from pkg_resources import iter_entry_points as iep
 import flask
 import gunicorn.app.base

--- a/test/integration/local/test_vw_serving.py
+++ b/test/integration/local/test_vw_serving.py
@@ -35,7 +35,7 @@ def test_vw_serving(local_instance_type, sagemaker_local_session, docker_image, 
                     "MODEL_METADATA_POLLING": "false"}
     
     model = sagemaker.model.Model(
-        image=docker_image,
+        image_uri=docker_image,
         role=role,
         env=environ_vars,
         name="test_env",
@@ -43,8 +43,8 @@ def test_vw_serving(local_instance_type, sagemaker_local_session, docker_image, 
         )
     model.deploy(initial_instance_count=1, instance_type=local_instance_type)
 
-    predictor = sagemaker.predictor.RealTimePredictor(
-        model.endpoint_name,
+    predictor = sagemaker.predictor.Predictor(
+        endpoint_name=model.endpoint_name,
         serializer=sagemaker.predictor.json_serializer,
         deserializer=sagemaker.predictor.json_deserializer,
         sagemaker_session=model.sagemaker_session)

--- a/vw/docker/8.7.0/Dockerfile
+++ b/vw/docker/8.7.0/Dockerfile
@@ -44,10 +44,6 @@ RUN \
   make && \
   make install
 
-# Update awscli for compatibility with the latest botocore version that breaks it
-# https://github.com/boto/boto3/issues/2596
-RUN pip install --upgrade awscli
-
 RUN pip install ipython \
                 sagemaker-containers==2.5.1 \
                 redis==3.2.1 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change fixes the 'docevents' import error  due to an upgrade in botocore. https://github.com/boto/boto3/issues/2596

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
