### PR TITLE
Update sagemaker-tensorflow-training to 20.1.4 (latest version).

### DIFF
--- a/ray/docker/1.0.0/Dockerfile.tf
+++ b/ray/docker/1.0.0/Dockerfile.tf
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir \
     dm-tree \
     tensorflow-probability \
     tf_slim \
-    sagemaker-tensorflow-training==20.1.3
+    sagemaker-tensorflow-training==20.1.4
 
 # https://github.com/ray-project/ray/issues/11773
 RUN pip install dataclasses


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating to include the latest commits from the `sagemaker-tensorflow-training` dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
