### PR TITLE
Update sagemaker-tensorflow-training to 20.1.4 for 0.8.5 container

### DIFF
--- a/ray/docker/0.8.5/Dockerfile.tf
+++ b/ray/docker/0.8.5/Dockerfile.tf
@@ -39,7 +39,8 @@ RUN pip install --no-cache-dir \
     setproctitle \
     dm-tree \
     tensorflow-probability \
-    tf_slim
+    tf_slim \
+    sagemaker-tensorflow-training==20.1.4
 
 # https://github.com/aws/sagemaker-rl-container/issues/39
 RUN pip install pyglet==1.3.2


### PR DESCRIPTION
*Description of changes:*
Update sagemaker-tensorflow-training to 20.1.4 for 0.8.5 container

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
